### PR TITLE
Forcepath: for pages optionally switch to path-based rule generation

### DIFF
--- a/ao_criticss_aas.php
+++ b/ao_criticss_aas.php
@@ -22,6 +22,7 @@ $ao_ccss_debug       = get_option('autoptimize_ccss_debug'      , FALSE);
 $ao_ccss_key         = get_option('autoptimize_ccss_key'        );
 $ao_ccss_keyst       = get_option('autoptimize_ccss_keyst'      );
 $ao_ccss_loggedin    = get_option('autoptimize_ccss_loggedin'   , TRUE );
+$ao_ccss_forcepath   = get_option('autoptimize_ccss_forcepath'  , FALSE );
 
 // Setup the rules array
 if (empty($ao_ccss_rules_raw)) {
@@ -102,6 +103,7 @@ function ao_ccss_settings_init() {
   register_setting('ao_ccss_options_group', 'autoptimize_ccss_key');
   register_setting('ao_ccss_options_group', 'autoptimize_ccss_keyst');
   register_setting('ao_ccss_options_group', 'autoptimize_ccss_loggedin');
+  register_setting('ao_ccss_options_group', 'autoptimize_ccss_forcepath');
 
   // Check if Autoptimize is installed
   if (!is_plugin_active('autoptimize/autoptimize.php') && !is_plugin_active('autoptimize-beta/autoptimize.php')) {
@@ -156,6 +158,8 @@ function ao_ccss_activation() {
   add_option('autoptimize_ccss_debug'      , '', '', 'no');
   add_option('autoptimize_ccss_key'        , '', '', 'no');
   add_option('autoptimize_ccss_keyst'      , '', '', 'no');
+  add_option('autoptimize_ccss_loggedin'   , '', '', 'no');
+  add_option('autoptimize_ccss_forcepath'  , '', '', 'no');
 
   // Create a scheduled event for the queue
   if (!wp_next_scheduled('ao_ccss_queue')) {
@@ -184,6 +188,8 @@ function ao_ccss_deactivation() {
   delete_option('autoptimize_ccss_key');
   delete_option('autoptimize_ccss_keyst');
   delete_option('autoptimize_ccss_version');
+  delete_option('autoptimize_ccss_loggedin');
+  delete_option('autoptimize_ccss_forcepath');
 
   // Remove scheduled events
   wp_clear_scheduled_hook('ao_ccss_queue');

--- a/inc/admin_settings_adv.php
+++ b/inc/admin_settings_adv.php
@@ -11,6 +11,7 @@ function ao_ccss_render_adv() {
   global $ao_ccss_rlimit;
   global $ao_ccss_noptimize;
   global $ao_ccss_loggedin;
+  global $ao_ccss_forcepath;
 
   // Get viewport size
   $viewport = ao_ccss_viewport();
@@ -80,7 +81,17 @@ function ao_ccss_render_adv() {
               </p>
             </td>
           </tr>
-
+          <tr>
+            <th scope="row">
+              <?php _e('Force path-based rules to be generated?', 'autoptimize'); ?>
+            </th>
+            <td>
+              <input type="checkbox" id="autoptimize_ccss_forcepath" name="autoptimize_ccss_forcepath" value="1" <?php checked(1 == $ao_ccss_forcepath); ?>>
+              <p class="notes">
+                <?php _e('By default rules are created per type of page, which keeps the number of rules lean ensuring great performance. You can forcefully switch this to path-based rule generation here, but do take into account this might generate a lot of rules which might impact the "time to first byte" for uncached pages.', 'autoptimize'); ?>
+              </p>
+            </td>
+          </tr>
           <tr>
             <th scope="row">
               <?php _e('Debug Mode', 'autoptimize'); ?>

--- a/inc/admin_settings_adv.php
+++ b/inc/admin_settings_adv.php
@@ -88,7 +88,7 @@ function ao_ccss_render_adv() {
             <td>
               <input type="checkbox" id="autoptimize_ccss_forcepath" name="autoptimize_ccss_forcepath" value="1" <?php checked(1 == $ao_ccss_forcepath); ?>>
               <p class="notes">
-                <?php _e('By default rules are created per type of page, which keeps the number of rules lean ensuring great performance. You can forcefully switch this to path-based rule generation here, but do take into account this might generate a lot of rules which might impact the "time to first byte" for uncached pages.', 'autoptimize'); ?>
+                <?php _e('By default one rule is created per type of page, which keeps the number of rules lean ensuring great performance. You can forcefully switch this to path-based rule generation for pages (including WooCommerce product pages) here, but do take into account this might generate a lot of rules which might impact the "time to first byte" for uncached pages.', 'autoptimize'); ?>
               </p>
             </td>
           </tr>

--- a/inc/core_enqueue.php
+++ b/inc/core_enqueue.php
@@ -27,11 +27,7 @@ function ao_ccss_enqueue($hash) {
 
     // Get request path and page type, and initialize the queue update flag
     $req_path          = strtok($_SERVER['REQUEST_URI'],'?');
-    if ($ao_ccss_forcepath) {
-      $req_type        = "";
-    } else {
-      $req_type        = ao_ccss_get_type();
-    }
+    $req_type          = ao_ccss_get_type();
     $job_qualify       = FALSE;
     $target_rule       = FALSE;
     $rule_properties   = FALSE;
@@ -90,7 +86,11 @@ function ao_ccss_enqueue($hash) {
 
       // Fill-in the new target rule
       $job_qualify = TRUE;
-      if ($ao_ccss_forcepath) {
+      
+      // Should we switch to path-base AUTO-rules? Conditions:
+      // 1. forcepath option has to be enabled (off by default)
+      // 2. request type should be (by default, but filterable) one off is_page, woo_is_product or woo_is_product_category
+      if ($ao_ccss_forcepath && in_array($req_type,apply_filters('autoptimize_filter_ccss_coreenqueue_forcepathfortype',array('is_page','woo_is_product','woo_is_product_category')))) {
         if ($req_path !== "/") {
           $target_rule = 'paths|' . $req_path;
         } else {

--- a/inc/core_enqueue.php
+++ b/inc/core_enqueue.php
@@ -91,7 +91,12 @@ function ao_ccss_enqueue($hash) {
       // Fill-in the new target rule
       $job_qualify = TRUE;
       if ($ao_ccss_forcepath) {
-        $target_rule = 'paths|' . $req_path;
+        if ($req_path !== "/") {
+          $target_rule = 'paths|' . $req_path;
+        } else {
+          // Exception; we don't want a path-based rule for "/" as that messes things up, hard-switch this to a type-based is_front_page rule
+          $target_rule = 'types|' . 'is_front_page';
+        }
       } else {
         $target_rule = 'types|' . $req_type;
       }

--- a/inc/core_enqueue.php
+++ b/inc/core_enqueue.php
@@ -19,14 +19,19 @@ function ao_ccss_enqueue($hash) {
   // Continue if queue is available
   if ($enqueue) {
 
-    // Attach required arrays
+    // Attach required arrays/ vars
     global $ao_ccss_rules;
     global $ao_ccss_queue_raw;
     global $ao_ccss_queue;
+    global $ao_ccss_forcepath;
 
     // Get request path and page type, and initialize the queue update flag
     $req_path          = strtok($_SERVER['REQUEST_URI'],'?');
-    $req_type          = ao_ccss_get_type();
+    if ($ao_ccss_forcepath) {
+      $req_type        = "";
+    } else {
+      $req_type        = ao_ccss_get_type();
+    }
     $job_qualify       = FALSE;
     $target_rule       = FALSE;
     $rule_properties   = FALSE;
@@ -53,8 +58,8 @@ function ao_ccss_enqueue($hash) {
       }
     }
 
-    // Match for types in rules if no path rule matches
-    if (!$job_qualify) {
+    // Match for types in rules if no path rule matches and if we're not enforcing paths
+    if (!$job_qualify && !$ao_ccss_forcepath) {
       foreach ($ao_ccss_rules['types'] as $type => $props) {
 
         // Prepare rule target and log
@@ -85,7 +90,11 @@ function ao_ccss_enqueue($hash) {
 
       // Fill-in the new target rule
       $job_qualify = TRUE;
-      $target_rule = 'types|' . $req_type;
+      if ($ao_ccss_forcepath) {
+        $target_rule = 'paths|' . $req_path;
+      } else {
+        $target_rule = 'types|' . $req_type;
+      }
       ao_ccss_log('Job submission QUALIFIED by MISSING rule for page type <' . $req_type . '> on path <' . $req_path . '>, new rule target is <' . $target_rule . '>', 3);
 
     // Or just log a job qualified by a matching rule

--- a/inc/core_enqueue.php
+++ b/inc/core_enqueue.php
@@ -55,7 +55,7 @@ function ao_ccss_enqueue($hash) {
     }
 
     // Match for types in rules if no path rule matches and if we're not enforcing paths
-    if (!$job_qualify && !$ao_ccss_forcepath) {
+    if (!$job_qualify && ( !$ao_ccss_forcepath || !in_array($req_type,apply_filters('autoptimize_filter_ccss_coreenqueue_forcepathfortype', array('is_page','woo_is_product','woo_is_product_category'))))) {
       foreach ($ao_ccss_rules['types'] as $type => $props) {
 
         // Prepare rule target and log

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -727,8 +727,8 @@ function ao_ccss_rule_update($ljid, $srule, $file, $hash) {
   // If rule doesn't exist, create an AUTO rule
   } else {
 
-    // AUTO rules are only for types
-    if ($trule[0] == 'types') {
+    // AUTO rules were only for types, but will now also work for paths
+    if ($trule[0] == 'types' || $trule[0] == 'paths') {
 
       // Set rule hash and file and action flag
       $rule['hash'] = $hash;
@@ -738,7 +738,7 @@ function ao_ccss_rule_update($ljid, $srule, $file, $hash) {
 
     // Log that no rule was created
     } else {
-      ao_ccss_log('AUTO rules are only for page types, no rule created', 3);
+      ao_ccss_log('Exception, no AUTO rule created', 3);
     }
   }
 


### PR DESCRIPTION
New advanced option to force path-based rules for pages (is_page, woo_is_product and woo_is_product_category), allowing for different CCSS for each different page (which is very relevant in the pagebuilder-world where 2 pages can be totally different).

see https://github.com/futtta/ao_critcss_aas/issues/40